### PR TITLE
Add PHP_INT_MAX to prioritise the child stylesheet

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -20,4 +20,4 @@ function hello_elementor_child_enqueue_scripts() {
 		'1.0.0'
 	);
 }
-add_action( 'wp_enqueue_scripts', 'hello_elementor_child_enqueue_scripts' );
+add_action( 'wp_enqueue_scripts', 'hello_elementor_child_enqueue_scripts', PHP_INT_MAX );


### PR DESCRIPTION
The child stylesheet does not currently override the parent stylesheet, forcing developers to use `!important` declarations for simple things like heading font styling. This occurs even if "Disable CSS & Fonts" is checked in Elementor's settings page.

This fix is based on https://wordpress.stackexchange.com/a/177861 and is tested as working.