### PR TITLE
Add PHP_INT_MAX

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -20,4 +20,4 @@ function hello_elementor_child_enqueue_scripts() {
 		'1.0.0'
 	);
 }
-add_action( 'wp_enqueue_scripts', 'hello_elementor_child_enqueue_scripts' );
+add_action( 'wp_enqueue_scripts', 'hello_elementor_child_enqueue_scripts', PHP_INT_MAX );


### PR DESCRIPTION
https://github.com/elementor/hello-theme-child/pull/8 for more information. This fix promotes the child theme's `style.css` file above the parent Hello Theme `style.css`.