### PR TITLE
wp_enqueue_scripts priority for style.css

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -20,4 +20,4 @@ function hello_elementor_child_enqueue_scripts() {
 		'1.0.0'
 	);
 }
-add_action( 'wp_enqueue_scripts', 'hello_elementor_child_enqueue_scripts' );
+add_action( 'wp_enqueue_scripts', 'hello_elementor_child_enqueue_scripts', 999 );


### PR DESCRIPTION
Hello Elementor loads style.min.css after child style.css which overwrites the styles of the child theme. I set the priority of the CSS of the child theme higher then main theme.