### PR TITLE
Feat: Tableau filtrable des projets avec DataTables

### DIFF
--- a/assets/js/projets-table.js
+++ b/assets/js/projets-table.js
@@ -1,0 +1,11 @@
+jQuery(document).ready(function ($) {
+	if ($('#projets-table').length) {
+		$('#projets-table').DataTable({
+			language: {
+				url: 'https://cdn.datatables.net/plug-ins/2.0.8/i18n/fr-FR.json',
+			},
+			pageLength: 25,
+			responsive: true,
+		});
+	}
+});

--- a/functions.php
+++ b/functions.php
@@ -19,5 +19,30 @@ function hello_elementor_child_enqueue_scripts() {
 		],
 		'1.0.0'
 	);
+
+	wp_enqueue_style(
+		'datatables',
+		'https://cdn.datatables.net/2.0.8/css/dataTables.dataTables.min.css',
+		[],
+		'2.0.8'
+	);
+
+	wp_enqueue_script(
+		'datatables',
+		'https://cdn.datatables.net/2.0.8/js/dataTables.min.js',
+		[ 'jquery' ],
+		'2.0.8',
+		true
+	);
+
+	wp_enqueue_script(
+		'projets-table',
+		get_stylesheet_directory_uri() . '/assets/js/projets-table.js',
+		[ 'datatables' ],
+		'1.0.0',
+		true
+	);
 }
 add_action( 'wp_enqueue_scripts', 'hello_elementor_child_enqueue_scripts', 20 );
+
+require_once get_stylesheet_directory() . '/inc/custom/client.php';

--- a/inc/custom/client.php
+++ b/inc/custom/client.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Shortcode [projets_table] — tableau filtrable des projets via DataTables
+ */
+
+function projets_table_shortcode() {
+	$query = new WP_Query( [
+		'post_type'      => 'projet',
+		'posts_per_page' => -1,
+		'post_status'    => 'publish',
+		'orderby'        => 'meta_value_num',
+		'meta_key'       => 'numero',
+		'order'          => 'ASC',
+	] );
+
+	if ( ! $query->have_posts() ) {
+		return '<p>Aucun projet trouvé.</p>';
+	}
+
+	ob_start();
+	?>
+	<table id="projets-table" class="display" style="width:100%">
+		<thead>
+			<tr>
+				<th>N°</th>
+				<th>Nom du projet</th>
+				<th>Catégorie</th>
+				<th>Localisation</th>
+				<th>Surface</th>
+				<th>Budget</th>
+				<th>Statut</th>
+			</tr>
+		</thead>
+		<tbody>
+		<?php
+		while ( $query->have_posts() ) :
+			$query->the_post();
+
+			$numero  = get_field( 'numero' );
+			$surface = get_field( 'surface' );
+			$budget  = get_field( 'budget' );
+			$statut  = get_field( 'statut' );
+			$commune = get_field( 'commune' );
+
+			$categories = get_the_terms( get_the_ID(), 'categorie_de_projet' );
+			$cat_name   = '';
+			if ( $categories && ! is_wp_error( $categories ) ) {
+				$cat_name = implode( ', ', wp_list_pluck( $categories, 'name' ) );
+			}
+			?>
+			<tr>
+				<td><?php echo esc_html( $numero ); ?></td>
+				<td><?php the_title(); ?></td>
+				<td><?php echo esc_html( $cat_name ); ?></td>
+				<td><?php echo esc_html( $commune ); ?></td>
+				<td><?php echo esc_html( $surface ); ?></td>
+				<td><?php echo esc_html( $budget ); ?></td>
+				<td><?php echo esc_html( $statut ); ?></td>
+			</tr>
+		<?php
+		endwhile;
+		wp_reset_postdata();
+		?>
+		</tbody>
+	</table>
+	<?php
+
+	return ob_get_clean();
+}
+add_shortcode( 'projets_table', 'projets_table_shortcode' );


### PR DESCRIPTION
- Shortcode [projets_table] dans inc/custom/client.php
- Colonnes : N°, Nom du projet, Catégorie, Localisation, Surface, Budget, Statut
- Champs ACF : numero, surface, budget, statut, commune + taxonomie categorie_de_projet
- Init DataTables FR dans assets/js/projets-table.js
- Enqueue DataTables 2.0.8 CDN (CSS + JS) dans functions.php